### PR TITLE
Port timestamp patch to 1.2.0

### DIFF
--- a/pf_driver/include/pf_driver/pf/pf_packet.h
+++ b/pf_driver/include/pf_driver/pf/pf_packet.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <ros/serialization.h>
+#include <ros/time.h>
 #include "pf_driver/PFR2000Header.h"
 #include "pf_driver/PFR2300Header.h"
 
@@ -11,6 +12,7 @@ class PFPacket
 {
 public:
   pf_driver::PFHeader header;
+  ros::Time last_acquired_point_stamp;
   std::vector<uint32_t> distance;
   std::vector<uint16_t> amplitude;
 

--- a/pf_driver/include/pf_driver/pf/pf_parser.h
+++ b/pf_driver/include/pf_driver/pf/pf_parser.h
@@ -38,6 +38,7 @@ public:
       size_t p_size = 0;
       if (!packet->parse_buf(buf, buf_len, remainder, p_size))
         break;
+      packet->last_acquired_point_stamp = ros::Time::now();
       results.push_back(std::move(packet));
       ++count;
 


### PR DESCRIPTION
This is almost the same as the patch for master, but the timestamping has changed between these versions (and both are wrong).

Patch for master: https://github.com/PepperlFuchs/pf_lidar_ros_driver/pull/125